### PR TITLE
Move secret key to environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ Get It Running
 You will then have access to your API key and API secret KEY, you will need these
 for the next steps.
 
-### Generate secret key
+### Setup Environment
 
-1. Create a `.env` file in the root of your project.
+1. Create a `.env` file in the root of your project and add to it the following contents
+```
+SHOPIFY_API_KEY=[your api key]
+SHOPIFY_API_SECRET=[your api secret]
+```
 2. Generate a secret key and add it to `.env` by running the following in the command line: `printf 'DJANGO_SECRET=' >> .env; python -c 'import random; print("".join([random.choice("abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)") for i in range(50)]))' >> .env`
 
 ### Run the App
@@ -38,7 +42,7 @@ for the next steps.
 Run the following commands in the repo. We use [pipenv](https://github.com/pypa/pipenv) to get running faster
 ```
 pipenv install
-SHOPIFY_API_KEY=[key] SHOPIFY_API_SECRET=[secret] pipenv run python manage.py runserver
+pipenv run python manage.py runserver
 ```
 
 You may get warnings about migrations, but they should not stop you.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,12 @@ Get It Running
 - Set Whitelisted redirection URL( http://localhost:8000/shopify/finalize/
 
 You will then have access to your API key and API secret KEY, you will need these
-for the next steps
+for the next steps.
+
+### Generate secret key
+
+1. Create a `.env` file in the root of your project.
+2. Generate a secret key and add it to `.env` by running the following in the command line: `printf 'DJANGO_SECRET=' >> .env; python -c 'import random; print("".join([random.choice("abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)") for i in range(50)]))' >> .env`
 
 ### Run the App
 

--- a/shopify_django_app/settings.py
+++ b/shopify_django_app/settings.py
@@ -19,8 +19,9 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = '@*38lzf_hhet!s%5nqokhug)u-d*8h_o+rt=_n(4-k&!pxqdgy'
+# Make this unique and store it as an environment variable. 
+# Do not share it with anyone or commit it to version control.
+SECRET_KEY = os.environ['DJANGO_SECRET']
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Re-implements https://github.com/Shopify/shopify_django_app/pull/24

It sets a good example for us to set the Django `SECRET_KEY` in an environment variable. This also makes it harder for someone to mistakenly copy this project a little too closely, making the secret key used in all of their cryptographic signing public.

It looks like during the [rewrite](https://github.com/Shopify/shopify_django_app/pull/27) this might've been missed.